### PR TITLE
Getting Out of a block of code with the command being 'out'

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,4 +50,5 @@
   <script src="js/variables.js"></script>
   <script src="js/iofunctions.js"></script>
   <script src="js/ifelse.js"></script>
+  <script src="js/braces.js"></script>
 </html>

--- a/js/braces.js
+++ b/js/braces.js
@@ -1,0 +1,19 @@
+function braceOut(){
+    var brace ='}';
+    var condition = "\n\n";
+    console.log(brace); 
+    if(textAfter.length>0 &&textAfter.indexOf(brace) > -1){
+       
+        programTextArea.value =textBefore + textAfter + condition;
+
+  programTextArea.focus();
+
+  programTextArea.selectionEnd = programTextArea.selectionEnd - textAfter.length;
+  programTextArea.selectionEnd = programTextArea.selectionEnd + 2;
+
+  textBefore = programTextArea.value.substring(0, programTextArea.selectionStart);
+  textAfter = programTextArea.value.substring(programTextArea.selectionEnd, programTextArea.value.length);
+}
+
+    
+}

--- a/js/braces.js
+++ b/js/braces.js
@@ -9,7 +9,7 @@ function braceOut(){
   programTextArea.focus();
 
   programTextArea.selectionEnd = programTextArea.selectionEnd - textAfter.length;
-  programTextArea.selectionEnd = programTextArea.selectionEnd + 2;
+  // programTextArea.selectionEnd = programTextArea.selectionEnd + 2;
 
   textBefore = programTextArea.value.substring(0, programTextArea.selectionStart);
   textAfter = programTextArea.value.substring(programTextArea.selectionEnd, programTextArea.value.length);

--- a/js/voicerecog.js
+++ b/js/voicerecog.js
@@ -55,14 +55,15 @@ recognition.onresult = function(event) {
     }
     if (splitWords[0] === 'if') {
         ifStatement();
-       
+    } 
     // if (splitWords[0] === 'else') {
     //
     // }
-    
+    if(splitWords[0]=='out'){
     braceOut();
+    }
     transcript = '';
     splitWords = [];
-}
+
 }
 

--- a/js/voicerecog.js
+++ b/js/voicerecog.js
@@ -55,11 +55,14 @@ recognition.onresult = function(event) {
     }
     if (splitWords[0] === 'if') {
         ifStatement();
-    }
+       
     // if (splitWords[0] === 'else') {
     //
     // }
-
+    
+    braceOut();
     transcript = '';
     splitWords = [];
 }
+}
+


### PR DESCRIPTION
When the user says 'out' the cursor moves out of the block of code. Moves right next to the '}' because in case of nested for loops giving more than 2 end-of-lines would move it out of the next block as well.